### PR TITLE
[WIP] Papertrail logging for docker worker

### DIFF
--- a/packer.yaml.jinja2
+++ b/packer.yaml.jinja2
@@ -52,6 +52,8 @@ provisioners:
   - type: shell
     scripts: {{builder.scripts}}
     execute_command: {{builder.vars.execute_command}}
+    environment_vars:
+      - 'PAPERTRAIL=logs6.papertrailapp.com:21045'
     # we reboot the host to update the kernel
     expect_disconnect: true
     # metal is slow to reboot

--- a/scripts/docker-worker-linux/25-syslog.sh
+++ b/scripts/docker-worker-linux/25-syslog.sh
@@ -6,6 +6,8 @@ set -exv
 helpers_dir=${MONOPACKER_HELPERS_DIR:-"/etc/monopacker/scripts"}
 . ${helpers_dir}/*.sh
 
+retry apt install -y rsyslog-gnutls
+
 cat << EOF > /etc/rsyslog.d/0-docker-worker.conf
 \$DefaultNetstreamDriverCAFile /etc/papertrail-bundle.pem # trust these CAs
 \$ActionSendStreamDriver gtls # use gtls netstream driver

--- a/scripts/docker-worker-linux/60-install-docker-worker.sh
+++ b/scripts/docker-worker-linux/60-install-docker-worker.sh
@@ -47,7 +47,7 @@ mkdir -p "$(dirname ${docker_worker_config})"
 mkdir -p "$(dirname ${worker_runner_config})"
 cat << EOF > "${worker_runner_config}"
 provider:
-    providerType: aws-provisioner
+    providerType: google
 worker:
     implementation: docker-worker
     path: "${docker_worker_code}"

--- a/template/builders/googlecompute.jinja2
+++ b/template/builders/googlecompute.jinja2
@@ -1,6 +1,6 @@
 - name: {{builder.vars.name}}
   type: googlecompute
-  image_name: {{builder.vars.name}}-{{builder.vars.image_suffix}}
+  image_name: {{builder.vars.name | replace("_","-")}}-{{builder.vars.image_suffix}}
   source_image_family: {{builder.vars.source_image_family}}
   ssh_username: {{builder.vars.ssh_username}}
   project_id: {{builder.vars.project_id}}

--- a/template/vars/googlecompute_bionic.yaml
+++ b/template/vars/googlecompute_bionic.yaml
@@ -1,5 +1,5 @@
 ---
-project_id: miles-packer-test
+project_id: bstack-dev-workers-2
 zone: us-west1-a
 ssh_username: ubuntu
 source_image_family: ubuntu-1804-lts


### PR DESCRIPTION
The fixes that are needed are to install a package and set a variable for the log destination.

Things still to do:

* [ ] Make it so that we can bring in things like `environment_vars` at the same time as bringing in secrets?
* [ ] Also allow overriding things like `project_id`
* [ ] Allow setting `providerType: <whatever>` in general for this config (mostly unrelated to logs but I used it for testing in google and want to bring it up here too)
* [ ] How do we make this seamlessly work with generic-worker on linux

These feel like related problems, how should we go about doing this?