### PR TITLE
bake docker_worker_gcp and docker_worker_gcp_l3 images in CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,6 +1,6 @@
 version: 1
 policy:
-  pullRequests: public
+  pullRequests: collaborators
 tasks:
   - $if: '(tasks_for == "github-pull-request"  && event["action"] in ["opened", "reopened", "synchronize"])'
     then:
@@ -54,5 +54,43 @@ tasks:
       metadata:
         name: monopacker tests
         description: runs tests, validates default packer builders
+        owner: taskcluster-internal@mozilla.com
+        source: ${event.repository.url}
+  - $if: '(tasks_for == "github-push" && true || event.after == "refs/heads/master")'
+    then:
+      taskId: { $eval: as_slugid("bake") }
+      created: { $fromNow: "" }
+      deadline: { $fromNow: "2 hours" }
+      provisionerId: taskcluster-imaging
+      workerType: taskcluster-imaging-ci
+      scopes:
+        - secrets:get:project/taskcluster/monopacker/gcloud_service_account
+      payload:
+        maxRunTime: 36000
+        features:
+          taskclusterProxy: true
+        image: taskcluster/monopacker:build
+        command:
+          - /bin/bash
+          - --login
+          - -cx
+          - |
+            mkdir /secrets
+            curl -s -L $TASKCLUSTER_PROXY_URL/api/secrets/v1/secret/project/taskcluster/monopacker/gcloud_service_account | jq '.secret' > /secrets/service_account.json
+            export GOOGLE_APPLICATION_CREDENTIALS=/secrets/service_account.json
+            CHECKOUT_DIR="/monopacker_checkout"
+            git clone "${event.repository.url}" "$CHECKOUT_DIR"
+            cd "$CHECKOUT_DIR"
+            git checkout "${event.after}"
+            pipenv install
+            pipenv run make build BUILDERS="docker_worker_gcp docker_worker_gcp_l3"
+        artifacts:
+          "packer-artifacts.json":
+            type: file
+            path: /monopacker_checkout/packer-artifacts.json
+            expires: { $fromNow: "1 year" }
+      metadata:
+        name: bake images
+        description: bake docker_worker_gcp and docker_worker_gcp_l3 images
         owner: taskcluster-internal@mozilla.com
         source: ${event.repository.url}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
         description: runs tests, validates default packer builders
         owner: taskcluster-internal@mozilla.com
         source: ${event.repository.url}
-  - $if: '(tasks_for == "github-push" && true || event.after == "refs/heads/master")'
+  - $if: '(tasks_for == "github-push" && event.after == "refs/heads/master")'
     then:
       taskId: { $eval: as_slugid("bake") }
       created: { $fromNow: "" }

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ templatepacker:
 	$(TEMPLATER) $(TEMPLATE) $(BUILDERS) > packer.yaml
 
 build: clean validate
-	time $(TEMPLATER) $(TEMPLATE) $(BUILDERS) | $(PACKER) build $(PACKER_VARS) $(PACKER_ARGS) -
+	/bin/bash -c "time $(TEMPLATER) $(TEMPLATE) $(BUILDERS) | $(PACKER) build $(PACKER_VARS) $(PACKER_ARGS) -"
 
 vagrant: BUILDERS=vagrant_virtualbox_bionic
 vagrant: build

--- a/builders/docker_worker_gcp_l3.yaml
+++ b/builders/docker_worker_gcp_l3.yaml
@@ -1,0 +1,13 @@
+# copy of docker_worker_gcp
+template: googlecompute
+platform: linux
+
+builder_var_files:
+  - default_linux
+  - default_gcp
+  - googlecompute_bionic
+
+script_directories:
+  - ubuntu-bionic
+  - worker-runner-linux
+  - docker-worker-linux


### PR DESCRIPTION
- bakes docker_worker_gcp and docker_worker_gcp_l3 builders in taskcluster on pushes to master
- depends on secret `secrets:get:project/taskcluster/monopacker/gcloud_service_account` and corresponding service account in `taskcluster-imaging`
  - should we use terraform for this? do we care?