### PR TITLE
switch default_aws WORKER_RUNNER_PROVIDER to aws-provider

### DIFF
--- a/template/vars/default_aws.yaml
+++ b/template/vars/default_aws.yaml
@@ -7,4 +7,4 @@ ami_regions: us-east-1,us-west-1
 volume_size: 40
 
 env_vars:
-  WORKER_RUNNER_PROVIDER: aws-provisioner
+  WORKER_RUNNER_PROVIDER: aws


### PR DESCRIPTION
- fixes startup failures for docker-worker instances in AWS under worker-manager/aws-provider