### PR TITLE
use the fxci-production-level3-workers project for L3 gcp images

### DIFF
--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -29,7 +29,7 @@ script_directories:
 The same concept applies to `builder_var_files`. Variables redefined in multiple `builder_var_files`
 will be overwritten by each subsequent file as it is loaded.
 
-`builder_vars`, as the name implies, override any variables specified in `builder_var_files`.
+`builder_vars` override any variables specified in `builder_var_files`.
 
 ### Adding a new builder
 

--- a/builders/docker_worker_gcp_trusted.yaml
+++ b/builders/docker_worker_gcp_trusted.yaml
@@ -1,4 +1,4 @@
-# copy of docker_worker_gcp
+# copy of docker_worker_gcp in l3 project
 template: googlecompute
 platform: linux
 
@@ -11,3 +11,8 @@ script_directories:
   - ubuntu-bionic
   - worker-runner-linux
   - docker-worker-linux
+
+# Note: this project disallows port 22, so baking images requires
+# temporarily allowing access
+builder_vars:
+  project_id: fxci-production-level3-workers


### PR DESCRIPTION
hopefully this clarifies generating trusted images

worth noting that you need temporary access to the project from relops (and a firewall rule that allows ssh in the project) to make this work