### PR TITLE
add docker_worker_gcp_community image identical to untrusted image

### DIFF
--- a/builders/docker_worker_gcp_community.yaml
+++ b/builders/docker_worker_gcp_community.yaml
@@ -1,0 +1,12 @@
+template: googlecompute
+platform: linux
+
+builder_var_files:
+  - default_linux
+  - default_gcp
+  - googlecompute_bionic
+
+script_directories:
+  - ubuntu-bionic
+  - worker-runner-linux
+  - docker-worker-linux


### PR DESCRIPTION
differentiates building images for community and firefoxci (and their names)