### PR TITLE
Fix volume creation in docker-worker AMIs

### DIFF
--- a/scripts/docker-worker-linux/60-install-docker-worker.sh
+++ b/scripts/docker-worker-linux/60-install-docker-worker.sh
@@ -68,8 +68,8 @@ fi
 cat << EOF > /etc/systemd/system/docker-worker.service
 [Unit]
 Description=Taskcluster docker worker
-After=docker.service $extra_required_units
-Requires=docker.service $extra_required_units
+After=docker.service docker-worker-disk-setup.service $extra_required_units
+Requires=docker.service docker-worker-disk-setup.service $extra_required_units
 
 [Service]
 Type=simple

--- a/scripts/docker-worker-linux/90-set-up-ephemeral-disks.sh
+++ b/scripts/docker-worker-linux/90-set-up-ephemeral-disks.sh
@@ -27,10 +27,15 @@ if ! lvdisplay | grep instance_storage; then
     # Find instance storage devices
     # c5 and newer has nvme* devices. The nvmeN devices can't be used
     # with vgcreate. But nvmeNnN can.
+    root_device=\$(mount | grep " / " | awk '{print \$1}')
     if [ -e /dev/nvme0 ]; then
-        devices=\$(ls /dev/nvme*n* | grep -v '/dev/nvme0$')
+        # root device is /dev/nvme[0-9]
+        root_device=\${root_device:0:10}
+        devices=\$(ls -1 /dev/nvme*n* | grep -v "\${root_device}")
     else
-        devices=\$(ls /dev/xvd* | grep -v '/dev/xvda')
+        # root device is /dev/xvd[a-z]
+        root_device=\${root_device:0:9}
+        devices=\$(ls -1 /dev/xvd* | grep -v "\${root_device}")
     fi
 
     if [ -z "\${devices}" ]; then


### PR DESCRIPTION
The script assumes the root filesystem in created in nvme0/xvda, which
is not necessarily the case.

We now make a more precise scan by looking and in what device the root
filesystem is mounted on and exclude it from the list of device to
create the volume group.