### PR TITLE
Avoid confirmation prompt in disk setup

### DIFF
--- a/scripts/docker-worker-linux/90-set-up-ephemeral-disks.sh
+++ b/scripts/docker-worker-linux/90-set-up-ephemeral-disks.sh
@@ -49,10 +49,10 @@ if ! lvdisplay | grep instance_storage; then
     for d in \$devices; do umount \$d || true; done
 
     # Create volume group containing all instance storage devices
-    echo \$devices | xargs vgcreate instance_storage
+    echo \$devices | xargs vgcreate -y instance_storage
 
     # Create logical volume with all storage
-    lvcreate -l 100%VG -n all instance_storage
+    lvcreate -y -l 100%VG -n all instance_storage
 else
     echo "Logical volume 'instance_storage' already exists"
 fi


### PR DESCRIPTION
Pass "-y" to `vgcreate` and `lvcreate` commands as the disk setup script
runs as a one-shot daemon.