### PR TITLE
Drop invalid packets to deal with moby/libnetwork#1090

### DIFF
--- a/scripts/ubuntu-bionic/30-networking.sh
+++ b/scripts/ubuntu-bionic/30-networking.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exv
+
+# init helpers
+helpers_dir=${MONOPACKER_HELPERS_DIR:-"/etc/monopacker/scripts"}
+. ${helpers_dir}/*.sh
+
+# https://github.com/moby/libnetwork/issues/1090
+retry apt install -y iptables-persistent
+iptables -I INPUT -m conntrack --ctstate INVALID -j DROP
+iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
This appears to be a fix for web-platform-tests/wpt#21529 as suggested by @Hexcles in linking to moby/libnetwork#1090

Baked an image from this and tried the repro steps for a while and it appeared to work.
Not too worried that this will cause other issues, seems pretty safe.

We can test this image in the tc workers for a bit and then roll it out everywhere or just
send it everywhere. I'd still like to do some of the other image cleanup work
we did to try to fix this before. It can wait until after the baremetal work lands though.
