### PR TITLE
Allow firefox-ci AMIs in staging environment

### DIFF
--- a/template/builders/amazon_ebs.jinja2
+++ b/template/builders/amazon_ebs.jinja2
@@ -1,6 +1,8 @@
 - name: {{builder.vars.name}}
   type: amazon-ebs
   communicator: ssh
+  ami_users:
+    - "710952102342"
   # for initial connect
   ssh_timeout: {{builder.vars.ssh_timeout}}
   # for reboots


### PR DESCRIPTION
This allows to test the images in staging before pushing to production.