### PR TITLE
Create /etc/taskcluster/secrets

### DIFF
--- a/packer.yaml.jinja2
+++ b/packer.yaml.jinja2
@@ -30,6 +30,7 @@ provisioners:
   # untar at /
   - type: shell
     inline:
+      - sudo mkdir -p /etc/taskcluster/secrets
       - sudo tar xvf /tmp/secrets.tar -C /
       - sudo chown root:root -R /etc/taskcluster
       - sudo chmod 0400 -R /etc/taskcluster/secrets


### PR DESCRIPTION
I think it's expected that the secrets tarball will create this
directory, but just in case let's create it.