### PR TITLE
build a simple way to deploy an un-released docker-worker

### DIFF
--- a/scripts/docker-worker-linux/60-install-docker-worker.sh
+++ b/scripts/docker-worker-linux/60-install-docker-worker.sh
@@ -29,8 +29,12 @@ docker_worker_start_script="/usr/local/bin/start-docker-worker"
 # use DOCKER_WORKER_VERSION, defaulting to TASKCLUSTER_VERSION
 docker_worker_version=${DOCKER_WORKER_VERSION:-$TASKCLUSTER_VERSION}
 
-# get the docker-worker tarball
-retry curl -L -o /tmp/docker-worker.tgz "https://github.com/taskcluster/taskcluster/releases/download/v$docker_worker_version/docker-worker-x64.tgz"
+# get the docker-worker tarball, either locally or from a TC release
+if [ -n "$DOCKER_WORKER_RELEASE_FILE" ]; then
+    mv "$DOCKER_WORKER_RELEASE_FILE" /tmp/docker-worker.tgz
+else
+    retry curl --fail -L -o /tmp/docker-worker.tgz "https://github.com/taskcluster/taskcluster/releases/download/v$docker_worker_version/docker-worker-x64.tgz"
+fi
 mkdir -p "${docker_worker_code}"
 tar xf /tmp/docker-worker.tgz -C "${docker_worker_code}" --strip-components 1
 rm /tmp/docker-worker.tgz

--- a/scripts/docker-worker-linux/README.md
+++ b/scripts/docker-worker-linux/README.md
@@ -1,0 +1,33 @@
+# docker-worker-linux
+
+This scripts directory installs docker-worker
+
+## Inputs
+
+* `DOCKER_WORKER_VERSION` - the version of docker-worker to install, defaulting to `$TASKCLUSTER_VERSION`
+* `DOCKER_WORKER_RELEASE_FILE` - a filename on the image containing a docker-worker release to install; this overrides `DOCKER_WORKER_VERSION`.
+* `WORKER_RUNNER_PROVIDER` - the worker-runner provider implementation
+
+## Behaviors
+
+* Installs the latest docker from the `download.docker.com` Ubuntu repository and configures it to start on boot.
+* Installs `docker-worker` and `worker-runner` along with a worker-runner config and a systemd unit to start them up.
+* Sets up a script to run on boot that formats and initializes any instance-local storage (ephemeral disks).
+  This script only works on AWS, and depends on finding `"tmpfsSize"` in the JSON blob in user data.
+
+## Notes
+
+### Installing a locally-built docker-worker
+
+To install a version of docker-worker that you have built locally and has not been released:
+
+* Put the docker-worker tarball at `files/docker-worker-x64.tgz`.
+
+* Set DOCKER_WORKER_RELEASE_FILE to `/docker-worker-x64.tgz` in your builder (or in a copy of an existing builder)
+  ```yaml
+  builder_vars:
+    env_vars:
+      DOCKER_WORKER_RELEASE_FILE: /docker-worker-x64.tgz
+  ```
+
+* Run the build as usual.

--- a/scripts/worker-runner-linux/01-install-worker-runner.sh
+++ b/scripts/worker-runner-linux/01-install-worker-runner.sh
@@ -8,6 +8,10 @@ helpers_dir=${MONOPACKER_HELPERS_DIR:-"/etc/monopacker/scripts"}
 
 # use WORKER_RUNNER_VERSION, defaulting to TASKCLUSTER_VERSION
 worker_runner_version=${WORKER_RUNNER_VERSION:-$TASKCLUSTER_VERSION}
-retry curl -fsSL -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster/releases/download/v${worker_runner_version}/start-worker-linux-amd64
+if [ -n "$WORKER_RUNNER_RELEASE_FILE" ]; then
+    mv "$WORKER_RUNNER_RELEASE_FILE" /usr/local/bin/start-worker
+else
+    retry curl -fsSL -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster/releases/download/v${worker_runner_version}/start-worker-linux-amd64
+fi
 file /usr/local/bin/start-worker
 chmod +x /usr/local/bin/start-worker

--- a/scripts/worker-runner-linux/README.md
+++ b/scripts/worker-runner-linux/README.md
@@ -1,0 +1,34 @@
+# worker-runnner-linux
+
+This scripts directory installs worker-runner and a papertrail log destination on linux (assuming amd64)
+
+## Inputs
+
+* `WORKER_RUNNER_VERSION` - the version of docker-worker to install, defaulting to `$TASKCLUSTER_VERSION`
+* `WORKER_RUNNER_RELEASE_FILE` - a filename on the image containing a docker-worker release to install; this overrides `WORKER_RUNNER_VERSION`.
+
+### Secrets
+
+* `/etc/taskcluster/secrets/worker_papertrail_dest` - the papertrail destination, of the form `logs17.papertrailapp.com:12345`
+
+## Behaviors
+
+* Download and install worker-runner at `/usr/local/bin/start-worker`
+* Set up rsyslog to forward system logs to the papertrail destination configured in the secret described above
+
+## Notes
+
+### Installing a locally-built worker-runner
+
+To install a version of worker-runner that you have built locally and has not been released:
+
+* Put the `start-worker-linux-amd64` binary at `files/start-worker-linux-amd64`
+
+* Set WORKER_RUNNER_RELEASE_FILE to `/start-worker-linux-amd64` in your builder (or in a copy of an existing builder)
+  ```yaml
+  builder_vars:
+    env_vars:
+      WORKER_RUNNER_RELEASE_FILE: /start-worker-linux-amd64
+  ```
+
+* Run the build as usual.


### PR DESCRIPTION
This isn't much, but adds a README about the docker_worker_linux scripts and instructions for doing this.

Fixes #74.