### PR TITLE
Filter out debug logging from docker-worker workers

### DIFF
--- a/scripts/worker-runner-linux/20-set-up-papertrail.sh
+++ b/scripts/worker-runner-linux/20-set-up-papertrail.sh
@@ -40,5 +40,5 @@ cat << EOF > /etc/rsyslog.d/0-taskcluster.conf
 \$ActionQueueSaveOnShutdown on
 \$ActionQueueTimeoutEnqueue 10
 \$ActionQueueDiscardSeverity 0
-*.* @@$PAPERTRAIL_HOST
+*.info @@$PAPERTRAIL_HOST
 EOF


### PR DESCRIPTION
The logging from systemd services is extremely verbose, and may even be
causing loss of log messages.

Fixes #76.