### PR TITLE
Revert "update TASKCLUSTER_VERSION to v36.0.0 (current)"

### DIFF
--- a/template/vars/taskcluster_version.yaml
+++ b/template/vars/taskcluster_version.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 36.0.0
+  TASKCLUSTER_VERSION: 30.0.2


### PR DESCRIPTION
Reverts taskcluster/monopacker#80

This never got released, and causes taskcluster/taskcluster#3521.