### PR TITLE
Add worker certificate placeholder to fakesecrets

### DIFF
--- a/fake_secrets.yaml
+++ b/fake_secrets.yaml
@@ -57,3 +57,65 @@
 - name: papertrail_logging_secret
   path: /etc/taskcluster/secrets/papertrail_secret
   value: "f2f3475398392f2783b8fd11c7a9fe1914346ed9"
+# cert for taskcluster-worker.net
+- name: taskcluster-worker.net cert
+  path: /etc/taskcluster/secrets/worker_livelog_tls_cert
+  value: |
+    -----BEGIN CERTIFICATE-----
+    MIIEVTCCAz2gAwIBAgIIYuftqmMuB3UwDQYJKoZIhvcNAQELBQAwgZAxCzAJBgNV
+    BAYTAlVTMQswCQYDVQQIEwJDQTELMAkGA1UEBxMCQ0ExDTALBgNVBAoTBERFTU8x
+    CzAJBgNVBAsTAklUMScwJQYDVQQDEx50YXNrY2x1c3Rlci13b3JrZXIuZXhhbXBs
+    ZS5jb20xIjAgBgkqhkiG9w0BCQEWE2ludmFsaWRAZXhhbXBsZS5jb20wHhcNMjEw
+    NDA4MTgzMDAwWhcNMjIwNDA4MTgzMDAwWjCBkDELMAkGA1UEBhMCVVMxCzAJBgNV
+    BAgTAkNBMQswCQYDVQQHEwJDQTENMAsGA1UEChMEREVNTzELMAkGA1UECxMCSVQx
+    JzAlBgNVBAMTHnRhc2tjbHVzdGVyLXdvcmtlci5leGFtcGxlLmNvbTEiMCAGCSqG
+    SIb3DQEJARYTaW52YWxpZEBleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD
+    ggEPADCCAQoCggEBAMGyRZj1WdiKqyb+fC1qIo3wgiwI6MH9GWT2We/xIwa/MVa8
+    vlqmucJspGmty1Q3EnVKhKhpo7iIaLO86mjFvcWp4eu6USc8TvHxIdPNKZw99Y9V
+    vwRfBU1dlXNgiFEWAaVjBfNtifHH8rFJIIiZjJMYK49HThi9Z/YfYmXZcPMXpkgN
+    GfmEB90Q8GU+hculY9+hhMgeSH5w9YEELkzSsavnyHVH+jmlWEGkwzeyaaFTBa2N
+    RLhlSY1dNp87oaSoUycYKtRa0jVecDASZpAjS2Ts0+OQX6tZblXIYslF+oqZPmgB
+    TDokcLQnJlqO+9BiTBmWTPbkS5AloBEu6qWF6YsCAwEAAaOBsDCBrTAMBgNVHRMB
+    Af8EAjAAMB0GA1UdDgQWBBQSrlEvAMmXfaXZcBRu34zSD2HtkjALBgNVHQ8EBAMC
+    A+gwEwYDVR0lBAwwCgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIedGFza2NsdXN0ZXIt
+    d29ya2VyLmV4YW1wbGUuY29tMBEGCWCGSAGG+EIBAQQEAwIGQDAeBglghkgBhvhC
+    AQ0EERYPeGNhIGNlcnRpZmljYXRlMA0GCSqGSIb3DQEBCwUAA4IBAQC9shSB+luO
+    mvMX7cHhsZ+Of+NO5PWDITMlTq1AL3W/v+qoUYIVMvT4C9OUOwumL1NGLnmSFAmp
+    VzT0nbujQcjV6E5D7BKWpKplT0hpV+qPu3Ur4R6ptbiZCO+eeUGxVHjSL/HLcuy2
+    tNQ8IoPzSDzr/oduK9NpzHEmWcIWZhHf6Ad3t+DPhRgdgQOgm2eVjstjyAKUuGjc
+    vTSgy5PMkEko2uSw3Il4KJw0V2ud/dW2uT+7Bu7N/QLDja3Px8YXF4ManQ91JeNf
+    pwmYwd2yFYuhzTscUOV+8k0TaZuHbP5TD4IR66OUk5yzdd6mxWt2II7d6cNWEWKh
+    Hl5b4sUvzab+
+    -----END CERTIFICATE-----
+
+# key for taskcluster-worker.net
+- name: taskcluster-worker.net key
+  path: /etc/taskcluster/secrets/worker_livelog_tls_key
+  value: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAwbJFmPVZ2IqrJv58LWoijfCCLAjowf0ZZPZZ7/EjBr8xVry+
+    Wqa5wmykaa3LVDcSdUqEqGmjuIhos7zqaMW9xanh67pRJzxO8fEh080pnD31j1W/
+    BF8FTV2Vc2CIURYBpWMF822J8cfysUkgiJmMkxgrj0dOGL1n9h9iZdlw8xemSA0Z
+    +YQH3RDwZT6Fy6Vj36GEyB5IfnD1gQQuTNKxq+fIdUf6OaVYQaTDN7JpoVMFrY1E
+    uGVJjV02nzuhpKhTJxgq1FrSNV5wMBJmkCNLZOzT45Bfq1luVchiyUX6ipk+aAFM
+    OiRwtCcmWo770GJMGZZM9uRLkCWgES7qpYXpiwIDAQABAoIBAAs43elnxaXTGulu
+    cxlafdgFaDVO6tVaaZ882qcZLHNWnnAtDUZJRJfsHXZ1+ELP0gTzpU3wmOi3FoHb
+    XyVk14LdPdafe9YvG0/PLauMxm1j9ZcxW5jQPIln86G0pRE1mjDP1OduoEBe2kPF
+    PdpMMyXOj6+EbRTn3F8ZIGVQPMgIq+6SC5y5xW8+aLevzLUmOO6IJvMjEyJd65yX
+    956RZtB86Vl+hqY+A9ZjY7JDKR21539JZ0t+WHfQbr0DtgyVkNo4PpSfEw6acibW
+    MhR++fi3sZX9u1ouHkhktXQjNcVldcE+Ss6BE4BpZ8hApAv90ASbULO+Y4BT/gnL
+    3T3pECkCgYEA4VVU7tBRV1P2r3mf4JebKDVPQfG98oy/fE1gooQjUiA+lKDqfMsP
+    juqybotcHiiZSXF+cE0A4wfu7SNCa4wEpXeQnOU66d+YK1sRJhQXgiYv/Ezu5D3b
+    5Lagkcx1e6jqSphYZqLerChuSGDyX487bRbOOyyZ5ehKNWfyrUlD1/cCgYEA3A6z
+    b8/FY2d4PfKHfjystrn1HouJYJEkS0C/PfF5RnjeaLpqj2G67jEs2NfVbTDri77c
+    1MN4FxZ2I1xjzPdKpwZ/NSYYtxJRpVxdOHtveKEg4BrSvoSm1fnWlWWtgoyDqFGl
+    QLD30/PT0pqWDN+aKVlC0tB8vpqb8rtyG2UjHg0CgYEAmPDUHuuh6gYBT4TbsRL1
+    qsrUKswrwq8pYPMb/fJ2Ds336+V0gpNI0hYWWdWZBpdDw4eW7B431eCSmL3v3RNC
+    LBUFQJiN7iNnIzZCY3gLpLjKpRKKqrwZvhj+zzbZHr+9ljfk+HTfcjZW9CVpHNcY
+    3Kg3/g39vwB1Ld6J5nft5m0CgYB8NPQE9VIlhF5zILRnhVm7HYUEQ6A72FCTBS2s
+    ieJ463olxKqm2XPIRAtbLZ/yrL0WuJkuolHjPjNaTCispRwG4Hzmg+VJV9arrlGT
+    suA9Rz0mIR24mWkNt6Ht22EvIZ6iX8sVk42ena5+3fA5ve/mzNIR6cmvT9ccD78d
+    RV2n9QKBgFLiKnF5kddZ3tCWRLun8F0eKkwAzqrc10ScEMShFnsISZzEYl4/F724
+    Uyz+yqKmWhn7kRh9IJjE7AaZyZyobAgraaiP5NnYhdnLOBm/bfQ5yKxxLXNP/epF
+    N9IrWLTT9m6gzeO3TJJ6sL3RR+qSq8w2MW3ehTaxrWwet/2ZIrDE
+    -----END RSA PRIVATE KEY-----

--- a/fake_secrets.yaml
+++ b/fake_secrets.yaml
@@ -57,7 +57,7 @@
 - name: papertrail_logging_secret
   path: /etc/taskcluster/secrets/papertrail_secret
   value: "f2f3475398392f2783b8fd11c7a9fe1914346ed9"
-# cert for taskcluster-worker.net
+# Certificate for the worker domain, as configured in a worker pool secret on Taskcluster with 'statelessHostname.domain'
 - name: taskcluster-worker.net cert
   path: /etc/taskcluster/secrets/worker_livelog_tls_cert
   value: |
@@ -88,7 +88,7 @@
     Hl5b4sUvzab+
     -----END CERTIFICATE-----
 
-# key for taskcluster-worker.net
+# Key for the certificate for the worker domain, as configured in a worker pool secret on Taskcluster with 'statelessHostname.domain'
 - name: taskcluster-worker.net key
   path: /etc/taskcluster/secrets/worker_livelog_tls_key
   value: |


### PR DESCRIPTION
For people who want to deploy TC and want logging, having this placeholder can be handy.

Fixes #95

(The cert is a placeholder self-signed cert I generated, which should have been a wildcard certificate I just realized.)