### PR TITLE
docker-worker: write '3' to /proc/sys/kernel/perf_event_paranoid

### DIFF
--- a/scripts/docker-worker-linux/70-kernel-perms.sh
+++ b/scripts/docker-worker-linux/70-kernel-perms.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -exv
+
+# init helpers
+helpers_dir=${MONOPACKER_HELPERS_DIR:-"/etc/monopacker/scripts"}
+for h in ${helpers_dir}/*.sh; do
+    . $h;
+done
+
+# Needed for performance counters to be available when using docker-worker
+# disableSeccomp capability - see:
+#   * https://github.com/taskcluster/taskcluster/pull/5800
+#
+# TODO: This should be removed when docker itself supports capability
+# CAP_PERFMON and docker-worker has been updated to use it. See
+# https://github.com/taskcluster/taskcluster/pull/5800#issuecomment-1330635417
+# for details.
+if [ -n "${PERF_EVENT_PARANOID_VALUE}" ]; then
+  echo "${PERF_EVENT_PARANOID_VALUE}" | sudo tee /proc/sys/kernel/perf_event_paranoid
+fi

--- a/template/vars/default_community.yaml
+++ b/template/vars/default_community.yaml
@@ -1,3 +1,4 @@
 env_vars:
   NUM_LOOPBACK_AUDIO_DEVICES: 32
   NUM_LOOPBACK_VIDEO_DEVICES: 1 # This is only used in docker-worker's own ci currently
+  PERF_EVENT_PARANOID_VALUE: 3


### PR DESCRIPTION
This is to fix taskcluster/taskcluster#5799 - but let's wait for @jschwartzentruber's approval in https://github.com/taskcluster/taskcluster/pull/5800#issuecomment-1330635417 before testing and landing this.