### PR TITLE
Bug 1808723 - Add GCP Ubuntu 18.04 tester images for FirefoxCI

### DIFF
--- a/builders/docker_firefoxci_gcp_lt.yaml
+++ b/builders/docker_firefoxci_gcp_lt.yaml
@@ -1,0 +1,14 @@
+template: googlecompute
+platform: linux
+
+builder_var_files:
+  - ub1804-gcp
+  - default_linux
+  - default_gcp
+  - default_firefoxci
+  - googlecompute_bionic
+
+script_directories:
+  - ubuntu-bionic
+  - worker-runner-linux
+  - docker-worker-linux


### PR DESCRIPTION
_**!! DEPENDS ON https://github.com/taskcluster/monopacker/pull/104 !!**_